### PR TITLE
Native multi-frame dicom parsing, multi-value native pixel parsing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,6 +38,15 @@
   version = "v1.2.2"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/image"
+  packages = [
+    "tiff",
+    "tiff/lzw"
+  ]
+  revision = "cc896f830cedae125428bc9fe1b0362aa91b3fb1"
+
+[[projects]]
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -64,6 +73,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8205646c23f9c80149b091366875231f45345464050551531bacf1842c8a48c2"
+  inputs-digest = "82e03f75274c55ce6610857ec141c3d08f519498e7bbc9c7a57e2c1d4bfd04bc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/dicom.go
+++ b/dicom.go
@@ -104,7 +104,7 @@ func ReadDataSet(in io.Reader, bytes int64, options ReadOptions) (*DataSet, erro
 	// Read the list of elements.
 	for buffer.Len() > 0 {
 		startLen := buffer.Len()
-		elem := ReadElement(buffer, options)
+		elem := ReadElement(buffer, file, options)
 		if buffer.Len() >= startLen { // Avoid silent infinite looping.
 			panic(fmt.Sprintf("ReadElement failed to consume data: %d %d: %v", startLen, buffer.Len(), buffer.Error()))
 		}

--- a/dicomio/buffer.go
+++ b/dicomio/buffer.go
@@ -427,6 +427,14 @@ func (d *Decoder) ReadUInt16() (v uint16) {
 	return v
 }
 
+func (d *Decoder) ReadUInt8() (v uint8) {
+	err := binary.Read(d, d.bo, &v)
+	if err != nil {
+		d.SetError(err)
+	}
+	return v
+}
+
 func (d *Decoder) ReadInt16() (v int16) {
 	err := binary.Read(d, d.bo, &v)
 	if err != nil {

--- a/dicomutil/dicomutil.go
+++ b/dicomutil/dicomutil.go
@@ -75,7 +75,7 @@ func generateEncapsulatedImage(frame []byte, frameIndex int, wg *sync.WaitGroup)
 
 func generateNativeImage(frame []uint16, frameIndex int, wg *sync.WaitGroup) {
 	defer wg.Done()
-	i := image.NewGray16(image.Rect(0, 0, 512, 512))
+	i := image.NewGray16(image.Rect(0, 0, 512, 512)) //TODO(suyash): dont assume 512 x 512
 	for j := 0; j < len(frame); j++ {
 		i.SetGray16(j % 512, j / 512, color.Gray16{Y: frame[j]})
 	}

--- a/dicomutil/dicomutil.go
+++ b/dicomutil/dicomutil.go
@@ -10,6 +10,10 @@ import (
 	"github.com/gradienthealth/go-dicom/dicomtag"
 	"github.com/gradienthealth/go-dicom/dicomlog"
 	"math"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"os"
 )
 
 var (
@@ -31,7 +35,6 @@ func main() {
 	if data == nil {
 		log.Panic("Error reading %s: %v", path, err)
 	}
-	log.Printf("Error reading %s: %v", path, err)
 	if *printMetadata {
 		for _, elem := range data.Elements {
 			fmt.Printf("%v\n", elem.String())
@@ -42,13 +45,28 @@ func main() {
 		for _, elem := range data.Elements {
 			if elem.Tag == dicomtag.PixelData {
 				data := elem.Value[0].(dicom.PixelDataInfo)
-				for _, frame := range data.Frames {
-					path := fmt.Sprintf("image.%d.jpg", n) // TODO: figure out the image format
-					n++
-					ioutil.WriteFile(path, frame, 0644)
-					fmt.Printf("%s: %d bytes\n", path, len(frame))
+				if data.Encapsulated {
+					for _, frame := range data.EncapsulatedFrames {
+						path := fmt.Sprintf("image.%d.jpg", n) // TODO: figure out the image format
+						n++
+						ioutil.WriteFile(path, frame, 0644)
+						fmt.Printf("%s: %d bytes\n", path, len(frame))
+					}
+				} else {
+					for _, frame := range data.NativeFrames {
+						i := image.NewGray16(image.Rect(0, 0, 512, 512))
+						for j := 0; j < len(frame); j++ {
+							i.SetGray16(j % 512, j / 512, color.Gray16{Y: frame[j]})
+						}
+						f, _ := os.Create(fmt.Sprintf("image_%d.jpg", n))
+						jpeg.Encode(f, i, &jpeg.Options{Quality: 100})
+						n++
+					}
 				}
 			}
 		}
 	}
+	log.Println("Complete.")
 }
+
+

--- a/dicomutil/dicomutil.go
+++ b/dicomutil/dicomutil.go
@@ -33,17 +33,17 @@ func main() {
 		dicomlog.SetLevel(math.MaxInt32)
 	}
 	path := flag.Arg(0)
-	data, err := dicom.ReadDataSetFromFile(path, dicom.ReadOptions{DropPixelData: !*extractImages})
-	if data == nil {
+	parsedData, err := dicom.ReadDataSetFromFile(path, dicom.ReadOptions{DropPixelData: !*extractImages})
+	if parsedData == nil {
 		log.Panic("Error reading %s: %v", path, err)
 	}
 	if *printMetadata {
-		for _, elem := range data.Elements {
+		for _, elem := range parsedData.Elements {
 			fmt.Printf("%v\n", elem.String())
 		}
 	}
 	if *extractImages {
-		for _, elem := range data.Elements {
+		for _, elem := range parsedData.Elements {
 			if elem.Tag == dicomtag.PixelData {
 				data := elem.Value[0].(dicom.PixelDataInfo)
 				if data.Encapsulated {
@@ -54,10 +54,14 @@ func main() {
 					}
 					wg.Wait()
 				} else {
+					x, y, err := getDimensions(parsedData)
+					if err != nil {
+
+					}
 					var wg sync.WaitGroup
 					for frameIndex, frame := range data.NativeFrames {
 						wg.Add(1)
-						go generateNativeImage(frame, frameIndex, &wg) // parse image as gray scale
+						go generateNativeImage(frame, frameIndex, x, y, &wg) // parse image as gray scale
 					}
 					wg.Wait()
 				}
@@ -74,14 +78,31 @@ func generateEncapsulatedImage(frame []byte, frameIndex int, wg *sync.WaitGroup)
 	fmt.Printf("%s: %d bytes\n", path, len(frame))
 }
 
-func generateNativeImage(frame [][]int, frameIndex int, wg *sync.WaitGroup) {
+func generateNativeImage(frame [][]int, frameIndex, x, y int, wg *sync.WaitGroup) {
 	defer wg.Done()
-	i := image.NewGray16(image.Rect(0, 0, 512, 512)) //TODO(suyash): dont assume 512 x 512
+	i := image.NewGray16(image.Rect(0, 0, x, y))
 	for j := 0; j < len(frame); j++ {
-		i.SetGray16(j%512, j/512, color.Gray16{Y: uint16(frame[j][0])}) // for now, assume we're not overflowing uint16, assume gray image
+		i.SetGray16(j%x, j/y, color.Gray16{Y: uint16(frame[j][0])}) // for now, assume we're not overflowing uint16, assume gray image
 	}
 	name := fmt.Sprintf("image_%d.jpg", frameIndex)
-	f, _ := os.Create(name)
+	f, err := os.Create(name)
+	if err != nil {
+		fmt.Printf("Error while creating file: %s", err.Error())
+	}
 	jpeg.Encode(f, i, &jpeg.Options{Quality: 100})
 	fmt.Printf("%s written \n", name)
+}
+
+func getDimensions(d *dicom.DataSet) (x, y int, err error) {
+	rows, err := d.FindElementByTag(dicomtag.Rows)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	cols, err := d.FindElementByTag(dicomtag.Columns)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return int(cols.MustGetUInt16()), int(rows.MustGetUInt16()), nil
 }

--- a/element.go
+++ b/element.go
@@ -446,7 +446,7 @@ func ParseFileHeader(d *dicomio.Decoder) []*Element {
 // endElement is an pseudoelement to cause the caller to stop reading the input.
 var endOfDataElement = &Element{Tag: dicomtag.Tag{Group: 0x7fff, Element: 0x7fff}}
 
-// ReadElement reads one DICOM data element. The parsedData ref must only be provided when potentially parsing PixelData,
+// ReadElement reads one DICOM data element. The parsedData ref must only be provided when potentially reading PixelData,
 // otherwise can be nil. ReadElement returns three kind of values.
 //
 // - On parse error, it returns nil and sets the error in d.Error().
@@ -537,7 +537,7 @@ func ReadElement(d *dicomio.Decoder, parsedData *DataSet, options ReadOptions) *
 			// We need Elements that have been already parsed (rows, cols, etc) to parse frames out of Native Pixel data
 			if parsedData == nil {
 				d.SetError(errors.New("dicom.ReadElement: parsedData is nil, must exist to parse Native pixel data"))
-				return elem // TODO(suyash) investigate error handling in this library
+				return nil // TODO(suyash) investigate error handling in this library
 			}
 
 			image, _, err := readNativeFrames(d, parsedData)
@@ -545,7 +545,7 @@ func ReadElement(d *dicomio.Decoder, parsedData *DataSet, options ReadOptions) *
 			if err != nil {
 				d.SetError(err)
 				dicomlog.Vprintf(1, "dicom.ReadElement: Error reading native frames")
-				return elem
+				return nil
 			}
 
 			data = append(data, *image)
@@ -767,10 +767,12 @@ func readNativeFrames(d *dicomio.Decoder, parsedData *DataSet) (pixelData *Pixel
 	if err != nil {
 		return nil, 0, err
 	}
+
 	cols, err := parsedData.FindElementByTag(dicomtag.Columns)
 	if err != nil {
 		return nil, 0, err
 	}
+
 	nof, err := parsedData.FindElementByTag(dicomtag.NumberOfFrames)
 	nFrames := 0
 	if err == nil {

--- a/element.go
+++ b/element.go
@@ -761,6 +761,7 @@ func readNativeFrames(d *dicomio.Decoder, parsedData *DataSet) (pixelData *Pixel
 		Encapsulated: false,
 	}
 
+	// Parse information from previously parsed attributes that are needed to parse Native Frames:
 	rows, err := parsedData.FindElementByTag(dicomtag.Rows)
 	if err != nil {
 		return nil, 0, err
@@ -771,16 +772,16 @@ func readNativeFrames(d *dicomio.Decoder, parsedData *DataSet) (pixelData *Pixel
 	}
 	nof, err := parsedData.FindElementByTag(dicomtag.NumberOfFrames)
 	nFrames := 0
-	if err != nil {
-		//TODO(suyash): explicitly check for not found error, currently assume single frame image
-		nFrames = 1
-	}
-	if nFrames == 0 {
+	if err == nil {
+		// No error, so parse number of frames
 		nFrames, err = strconv.Atoi(nof.MustGetString()) // odd that number of frames is encoded as a string...
 		if err != nil {
 			dicomlog.Vprintf(1, "ERROR converting nof")
 			return nil, 0, err
 		}
+	} else {
+		// error fetching NumberOfFrames, so default to 1. TODO: revisit
+		nFrames = 1
 	}
 
 	b, err := parsedData.FindElementByTag(dicomtag.BitsAllocated)

--- a/element.go
+++ b/element.go
@@ -446,7 +446,8 @@ func ParseFileHeader(d *dicomio.Decoder) []*Element {
 // endElement is an pseudoelement to cause the caller to stop reading the input.
 var endOfDataElement = &Element{Tag: dicomtag.Tag{Group: 0x7fff, Element: 0x7fff}}
 
-// ReadElement reads one DICOM data element. It returns three kind of values.
+// ReadElement reads one DICOM data element. The parsedData ref must only be provided when potentially parsing PixelData,
+// otherwise can be nil. ReadElement returns three kind of values.
 //
 // - On parse error, it returns nil and sets the error in d.Error().
 //

--- a/parser_test.go
+++ b/parser_test.go
@@ -30,7 +30,7 @@ func testWriteDataElement(t *testing.T, bo binary.ByteOrder, implicit dicomio.Is
 	data := e.Bytes()
 	// Read them back.
 	d := dicomio.NewBytesDecoder(data, bo, implicit)
-	elem0 := dicom.ReadElement(d, dicom.ReadOptions{})
+	elem0 := dicom.ReadElement(d, nil, dicom.ReadOptions{})
 
 	require.NoError(t, d.Error())
 	tag := dicomtag.Tag{0x18, 0x9755}
@@ -38,7 +38,7 @@ func testWriteDataElement(t *testing.T, bo binary.ByteOrder, implicit dicomio.Is
 	assert.Equal(t, len(elem0.Value), 1)
 	assert.Equal(t, elem0.Value[0].(string), "FooHah")
 	tag = dicomtag.Tag{Group: 0x20, Element: 0x9057}
-	elem1 := dicom.ReadElement(d, dicom.ReadOptions{})
+	elem1 := dicom.ReadElement(d, nil, dicom.ReadOptions{})
 	require.NoError(t, d.Error())
 	assert.Equal(t, elem1.Tag, tag)
 	assert.Equal(t, len(elem1.Value), 2)

--- a/writer.go
+++ b/writer.go
@@ -161,7 +161,7 @@ func WriteElement(e *dicomio.Encoder, elem *Element) {
 			encodeElementHeader(e, elem.Tag, vr, uint32(len(image.NativeFrames[0])))
 			buf := new(bytes.Buffer)
 			buf.Grow(2 * len(image.NativeFrames[0]))
-			binary.Write(buf, binary.LittleEndian, image.NativeFrames[0])
+			binary.Write(buf, binary.LittleEndian, image.NativeFrames[0]) //TODO(suyash) revisit little endian
 			e.WriteBytes(buf.Bytes())
 		}
 		return

--- a/writer.go
+++ b/writer.go
@@ -148,14 +148,14 @@ func WriteElement(e *dicomio.Encoder, elem *Element) {
 		if elem.UndefinedLength {
 			encodeElementHeader(e, elem.Tag, vr, undefinedLength)
 			writeBasicOffsetTable(e, image.Offsets)
-			for _, image := range image.Frames {
+			for _, image := range image.EncapsulatedFrames {
 				writeRawItem(e, image)
 			}
 			encodeElementHeader(e, dicomtag.SequenceDelimitationItem, "" /*not used*/, 0)
 		} else {
-			doassert(len(image.Frames) == 1, image.Frames) // TODO
-			encodeElementHeader(e, elem.Tag, vr, uint32(len(image.Frames[0])))
-			e.WriteBytes(image.Frames[0])
+			doassert(len(image.EncapsulatedFrames) == 1, image.EncapsulatedFrames) // TODO
+			encodeElementHeader(e, elem.Tag, vr, uint32(len(image.EncapsulatedFrames[0])))
+			e.WriteBytes(image.EncapsulatedFrames[0])
 		}
 		return
 	}


### PR DESCRIPTION
This change:
* Implements multi-frame parsing of native (non-encapsulated) pixel data in DICOMs (closes #2) 
* Implements parsing of multi-value native pixel data in DICOMs (closes #8) 
* Updates the `dicomutil` utility program to parse and write JPG images of native pixel data as well
