### PR TITLE
Implement buffered reading [10x speed increase]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ _testmain.go
 
 # Test files
 out
+
+.idea
+build
+vendor

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,15 @@
 
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:9ae31ce33b4bab257668963e844d98765b44160be4ee98cafc44637a213e530d"
   name = "github.com/gobwas/glob"
   packages = [
     ".",
@@ -17,27 +20,41 @@
     "syntax/ast",
     "syntax/lexer",
     "util/runes",
-    "util/strings"
+    "util/strings",
   ]
+  pruneopts = "UT"
   revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
   version = "v0.2.3"
 
 [[projects]]
+  digest = "1:cfa0d7741863a0e1d30e0ccdd4b48a96a471cdb47892303de8b92c3713af3e77"
+  name = "github.com/pkg/profile"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5b67d428864e92711fcbd2f8629456121a56d91f"
+  version = "v1.2.1"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
+  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:aa4d6967a3237f8367b6bf91503964a77183ecf696f1273e8ad3551bb4412b5f"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -56,14 +73,22 @@
     "language",
     "runes",
     "transform",
-    "unicode/cldr"
+    "unicode/cldr",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8205646c23f9c80149b091366875231f45345464050551531bacf1842c8a48c2"
+  input-imports = [
+    "github.com/gobwas/glob",
+    "github.com/pkg/profile",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "golang.org/x/text/encoding",
+    "golang.org/x/text/encoding/htmlindex",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/dicomutil/dicomutil.go
+++ b/dicomutil/dicomutil.go
@@ -16,7 +16,8 @@ import (
 	"github.com/gradienthealth/dicom"
 	"github.com/gradienthealth/dicom/dicomlog"
 	"github.com/gradienthealth/dicom/dicomtag"
-)
+
+	)
 
 var (
 	printMetadata       = flag.Bool("print-metadata", true, "Print image metadata")

--- a/dicomutil/dicomutil.go
+++ b/dicomutil/dicomutil.go
@@ -16,8 +16,7 @@ import (
 	"github.com/gradienthealth/dicom"
 	"github.com/gradienthealth/dicom/dicomlog"
 	"github.com/gradienthealth/dicom/dicomtag"
-
-	)
+)
 
 var (
 	printMetadata       = flag.Bool("print-metadata", true, "Print image metadata")

--- a/parse.go
+++ b/parse.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gradienthealth/dicom/dicomio"
 	"github.com/gradienthealth/dicom/dicomlog"
 	"github.com/gradienthealth/dicom/dicomtag"
+	"bufio"
 )
 
 // GoDICOMImplementationClassUIDPrefix defines the UID prefix for
@@ -46,7 +47,7 @@ type parser struct {
 
 // NewParser initializes and returns a new Parser
 func NewParser(in io.Reader, bytesToRead int64, frameChannel chan *Frame) (Parser, error) {
-	buffer := dicomio.NewDecoder(in, bytesToRead, binary.LittleEndian, dicomio.ExplicitVR)
+	buffer := dicomio.NewDecoder(bufio.NewReader(in), bytesToRead, binary.LittleEndian, dicomio.ExplicitVR)
 	p := parser{
 		decoder:      buffer,
 		frameChannel: frameChannel,


### PR DESCRIPTION
After using `pprof` to run CPU profiles of the existing code (which I thought seemed slower than it should be), I noticed a lot of CPU time was going to syscalls. Given the file reading task that this code was performing this did not make sense (likey something I/O heavy going on here). After auditing the code I realized that the default readers in this codebase were unbuffered. Changing to buffered readers led to a 10x speed boost when reading a Native PixelData dicom from disk:

Before:
```
./build/dicomutil --extract-images-stream   13.86s user 9.69s system 106% cpu 22.204 total
```
After:
```
./build/dicomutil --extract-images-stream   2.91s user 0.38s system 159% cpu 2.061 total
```

pprof before:
```
(pprof) top5
Showing nodes accounting for 16.58s, 97.13% of 17.07s total
Dropped 69 nodes (cum <= 0.09s)
Showing top 5 nodes out of 43
      flat  flat%   sum%        cum   cum%
    15.46s 90.57% 90.57%     15.46s 90.57%  syscall.Syscall
     0.53s  3.10% 93.67%      0.58s  3.40%  runtime.mallocgc
     0.23s  1.35% 95.02%      0.23s  1.35%  runtime.greyobject
     0.20s  1.17% 96.19%      0.20s  1.17%  image.Rectangle.At
     0.16s  0.94% 97.13%      0.49s  2.87%  runtime.scanobject
```

pprof after change:
```
(pprof) top10
Showing nodes accounting for 2680ms, 92.10% of 2910ms total
Dropped 20 nodes (cum <= 14.55ms)
Showing top 10 nodes out of 82
      flat  flat%   sum%        cum   cum%
     930ms 31.96% 31.96%     1050ms 36.08%  runtime.mallocgc
     860ms 29.55% 61.51%     1510ms 51.89%  github.com/gradienthealth/dicom.readNativeFrames
     220ms  7.56% 69.07%      220ms  7.56%  image.(*Gray16).SetGray16
     210ms  7.22% 76.29%      210ms  7.22%  runtime.greyobject
     140ms  4.81% 81.10%      140ms  4.81%  syscall.Syscall
     110ms  3.78% 84.88%      360ms 12.37%  runtime.scanobject
      60ms  2.06% 86.94%      900ms 30.93%  main.generateNativeImage
      60ms  2.06% 89.00%       60ms  2.06%  runtime.memclrNoHeapPointers
      50ms  1.72% 90.72%       50ms  1.72%  runtime.memmove
      40ms  1.37% 92.10%       40ms  1.37%  runtime.heapBitsForObject
```